### PR TITLE
Fix Hardware Number function

### DIFF
--- a/DeviceGuru.swift
+++ b/DeviceGuru.swift
@@ -213,8 +213,8 @@ public class DeviceGuru {
   class public func hardwareNumber() -> Float {
     let hardware = hardwareString()
     if let deviceList = getDeviceList() {
-      let hardwareDetail = deviceList[hardware] as? [String: Float]
-      if let hardwareNumber = hardwareDetail?["version"] {
+      let hardwareDetail = deviceList[hardware] as? [String: AnyObject]
+      if let hardwareNumber = hardwareDetail?["version"] as? Float {
         return hardwareNumber
       }
     }


### PR DESCRIPTION
The cast to [String: Float] fails as the "description" is a String, not a Float.
Instead, cast to [String: AnyObject] and see if "version" can be cast to a Float.
