### PR TITLE
Fix typo in `hardwareString()` documentation

### DIFF
--- a/DeviceGuru.swift
+++ b/DeviceGuru.swift
@@ -12,7 +12,7 @@ import UIKit
 
 open class DeviceGuru {
   
-  /// This method retruns the hardware type
+  /// This method returns the hardware type
   ///
   ///
   /// - returns: raw `String` of device type


### PR DESCRIPTION
retruns -> returns
