### PR TITLE
Fix Simultaneous accesses to var warnings / errors with Swift 3.2 and Swift 4

### DIFF
--- a/DeviceGuru.swift
+++ b/DeviceGuru.swift
@@ -20,9 +20,9 @@ open class DeviceGuru {
   class open func hardwareString() -> String {
     var name: [Int32] = [CTL_HW, HW_MACHINE]
     var size: Int = 2
-    sysctl(&name, 2, nil, &size, &name, 0)
+    sysctl(&name, 2, nil, &size, nil, 0)
     var hw_machine = [CChar](repeating: 0, count: Int(size))
-    sysctl(&name, 2, &hw_machine, &size, &name, 0)
+    sysctl(&name, 2, &hw_machine, &size, nil, 0)
     
     let hardware: String = String(cString: hw_machine)
     return hardware


### PR DESCRIPTION
This fixes the following warnings (Swift 3.2) or errors (Swift 4) when using Xcode 9:
<img width="1080" alt="errors" src="https://user-images.githubusercontent.com/1856655/27694900-c50500de-5ced-11e7-8279-3b51390b851f.png">

Background probably: https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md

My googling showed that sysctl doesn't need the 5th parameter to be set (only when writing, which isn't done here).