### PR TITLE
Added new iPad Pro and a platform method on DeviceGuru class

### DIFF
--- a/DeviceGuru.podspec
+++ b/DeviceGuru.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'DeviceGuru'
-  s.version = '2.1.0'
+  s.version = '2.2.0'
   s.license = 'MIT'
   s.summary = 'DeviceGuru helps identifying the exact harware type of the device. e.g. iPhone 6 or iPhone 6s.'
   s.homepage = 'https://github.com/InderKumarRathore/DeviceGuru'

--- a/DeviceGuru.swift
+++ b/DeviceGuru.swift
@@ -119,6 +119,10 @@ open class DeviceGuru {
     if (hardware == "iPad6,4")           { return Hardware.ipad_PRO_97_WIFI_CELLULAR }
     if (hardware == "iPad6,7")           { return Hardware.ipad_PRO_WIFI }
     if (hardware == "iPad6,8")           { return Hardware.ipad_PRO_WIFI_CELLULAR }
+    if (hardware == "iPad7,1")           { return Hardware.ipad_PRO_2G_WIFI }
+    if (hardware == "iPad7,2")           { return Hardware.ipad_PRO_2G_WIFI_CELLULAR }
+    if (hardware == "iPad7,3")           { return Hardware.ipad_PRO_105_WIFI }
+    if (hardware == "iPad7,4")           { return Hardware.ipad_PRO_105_WIFI_CELLULAR }
     
     if (hardware == "iPad6,11")          { return Hardware.ipad_2017_WIFI }
     if (hardware == "iPad6,12")          { return Hardware.ipad_2017_WIFI_CELLULAR }
@@ -147,6 +151,24 @@ open class DeviceGuru {
     
     return Hardware.not_AVAILABLE
   }
+    
+    /// This method returns the Platform enum depending upon harware string
+    ///
+    ///
+    /// - returns: `Platform` type of the device
+    ///
+    class open func platform() -> Platform {
+        
+        let hardware = hardwareString().lowercased()
+        
+        if hardware.hasPrefix(Platform.iPhone.rawValue) { return Platform.iPhone }
+        if hardware.hasPrefix(Platform.iPodTouch.rawValue) { return Platform.iPodTouch }
+        if hardware.hasPrefix(Platform.iPad.rawValue) { return Platform.iPad }
+        if hardware.hasPrefix(Platform.appleTV.rawValue) { return Platform.appleTV }
+        if hardware.hasPrefix(Platform.appleWatch.rawValue) { return Platform.appleWatch }
+        
+        return Platform.unknown
+    }
   
   
   /// This method returns the readable description of hardware string
@@ -231,8 +253,12 @@ open class DeviceGuru {
       
     case .ipad_PRO_97_WIFI, .ipad_PRO_97_WIFI_CELLULAR:
         return CGSize(width: 4032, height: 3024)
+        
     case .ipad_PRO_WIFI, .ipad_PRO_WIFI_CELLULAR:
       return CGSize(width: 3264, height: 2448)
+        
+    case .ipad_PRO_2G_WIFI, .ipad_PRO_2G_WIFI_CELLULAR, .ipad_PRO_105_WIFI, .ipad_PRO_105_WIFI_CELLULAR:
+        return CGSize(width: 4032, height: 3024)
  
     default:
       print("We have no resolution for your device's camera listed in this category. Please, take photo with back camera of your device, get its resolution in pixels (via Preview Cmd+I for example) and add a comment to this repository (https://github.com/InderKumarRathore/DeviceGuru) on GitHub.com in format Device = Wpx x Hpx.")

--- a/DeviceList.plist
+++ b/DeviceList.plist
@@ -436,6 +436,34 @@
 		<key>name</key>
 		<string>9.7-inch iPad (Wi-Fi + Cellular)</string>
 	</dict>
+	<key>iPad7,1</key>
+	<dict>
+		<key>version</key>
+		<real>7.1</real>
+		<key>name</key>
+		<string>iPad Pro 12.9-Inch (Wi-Fi Only - 2nd Gen)</string>
+	</dict>
+	<key>iPad7,2</key>
+	<dict>
+		<key>version</key>
+		<real>7.2</real>
+		<key>name</key>
+		<string>iPad Pro 12.9-Inch (Wi-Fi/Cell - 2nd Gen)</string>
+	</dict>
+	<key>iPad7,3</key>
+	<dict>
+		<key>version</key>
+		<real>7.3</real>
+		<key>name</key>
+		<string>iPad Pro 10.5-Inch (Wi-Fi Only)</string>
+	</dict>
+	<key>iPad7,4</key>
+	<dict>
+		<key>version</key>
+		<real>7.4</real>
+		<key>name</key>
+		<string>iPad Pro 10.5-Inch (Wi-Fi/Cellular)</string>
+	</dict>
 	<key>appleTV1,1</key>
 	<dict>
 		<key>version</key>

--- a/Hardware.swift
+++ b/Hardware.swift
@@ -76,6 +76,10 @@ public enum Hardware {
     case ipad_PRO_97_WIFI_CELLULAR
     case ipad_PRO_WIFI
     case ipad_PRO_WIFI_CELLULAR
+    case ipad_PRO_2G_WIFI
+    case ipad_PRO_2G_WIFI_CELLULAR
+    case ipad_PRO_105_WIFI
+    case ipad_PRO_105_WIFI_CELLULAR
     
     case ipad_2017_WIFI
     case ipad_2017_WIFI_CELLULAR
@@ -94,4 +98,20 @@ public enum Hardware {
     case appleWatch_SERIES_1_42
 
     case simulator
+}
+
+/// Enum of the different Apple's device platforms
+public enum Platform: String {
+    
+    case iPhone = "iphone"
+    
+    case iPodTouch = "ipod"
+    
+    case iPad = "ipad"
+    
+    case appleTV = "appletv"
+    
+    case appleWatch = "watch"
+    
+    case unknown = "unknown"
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ In your code:
 ``` swift
 let deviceName = DeviceGuru.hardware()
 let deviceCode = DeviceGuru.hardwareString()
-print("\(deviceName) - \(deviceCode)") //Ex: iphone_7_PLUS - iPhone9,2
+let platform = DeviceGuru.platform()
+print("\(deviceName) - \(deviceCode) - \(platform.rawValue)") //Ex: iphone_7_PLUS - iPhone9,2 - iphone
 ```
 
 ### Device codes
@@ -109,6 +110,10 @@ iPad Pro  | ```ipad_PRO_WIFI``` | ```iPad6,7```
 iPad Pro Cellular  | ```ipad_PRO_WIFI_CELLULAR``` | ```iPad6,8```
 9.7-inch iPad Wifi  | ```ipad_2017_WIFI``` | ```iPad6,11```
 9.7-inch iPad Wifi + Cellular | ```ipad_2017_WIFI_CELLULAR``` | ```iPad6,12```
+iPad Pro 12.9-Inch (Wi-Fi Only - 2nd Gen) | ```ipad_PRO_2G_WIFI``` | ```iPad7,1```
+iPad Pro 12.9-Inch (Wi-Fi/Cell - 2nd Gen) | ```ipad_PRO_2G_WIFI_CELLULAR``` | ```iPad7,2```
+iPad Pro 10.5-Inch (Wi-Fi Only) | ```ipad_PRO_105_WIFI``` | ```iPad7,3```
+iPad Pro 10.5-Inch (Wi-Fi/Cellular) | ```ipad_PRO_105_WIFI_CELLULAR``` | ```iPad7,4```
 
 ##### Apple TV
 Device | hardware() | hardwareString()


### PR DESCRIPTION
- Added iPad Pro 12,9" Gen 2 (2017)
- Added iPad Pro 10,5"
- Added method to known the current platform (iPhone, iPod, iPad,
AppleTV, Apple Watch)
- Bumped Pod version to 2.2.0