### PR TITLE
Add 2018 iPad models.

### DIFF
--- a/DeviceGuru.podspec
+++ b/DeviceGuru.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'DeviceGuru'
-  s.version = '4.1.0'
+  s.version = '4.0.1'
   s.license = 'MIT'
   s.summary = 'DeviceGuru helps identifying the exact harware type of the device. e.g. iPhone 6 or iPhone 6s.'
   s.homepage = 'https://github.com/InderKumarRathore/DeviceGuru'

--- a/DeviceGuru.podspec
+++ b/DeviceGuru.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'DeviceGuru'
-  s.version = '4.0.0'
+  s.version = '4.1.0'
   s.license = 'MIT'
   s.summary = 'DeviceGuru helps identifying the exact harware type of the device. e.g. iPhone 6 or iPhone 6s.'
   s.homepage = 'https://github.com/InderKumarRathore/DeviceGuru'

--- a/DeviceGuru.swift
+++ b/DeviceGuru.swift
@@ -153,6 +153,8 @@ open class DeviceGuru {
     if (hardware == "iPad7,2")           { return Hardware.ipadPro2g_wifi_cellular }
     if (hardware == "iPad7,3")           { return Hardware.ipadPro_105_wifi }
     if (hardware == "iPad7,4")           { return Hardware.ipadPro_105_wifi_cellular }
+    if (hardware == "iPad7,5")           { return Hardware.ipad6_wifi }
+    if (hardware == "iPad7,6")           { return Hardware.ipad6_wifi_cellular }
 
     if (hardware == "AppleTV1,1")        { return Hardware.appleTv1g }
     if (hardware == "AppleTV2,1")        { return Hardware.appleTv2g }

--- a/DeviceList.plist
+++ b/DeviceList.plist
@@ -506,6 +506,20 @@
 		<key>name</key>
 		<string>iPad Pro 10.5-Inch (Wi-Fi/Cellular)</string>
 	</dict>
+    <key>iPad7,5</key>
+    <dict>
+        <key>version</key>
+        <real>7.5</real>
+        <key>name</key>
+        <string>iPad 9.7-Inch 2018 (Wi-Fi Only)</string>
+    </dict>
+    <key>iPad7,6</key>
+    <dict>
+        <key>version</key>
+        <real>7.6</real>
+        <key>name</key>
+        <string>iPad 9.7-Inch 2018 (Wi-Fi/Cellular)</string>
+    </dict>
 	<key>appleTV1,1</key>
 	<dict>
 		<key>version</key>

--- a/Hardware.swift
+++ b/Hardware.swift
@@ -97,6 +97,9 @@ public enum Hardware {
   case ipadPro_105_wifi
   case ipadPro_105_wifi_cellular
 
+  case ipad6_wifi
+  case ipad6_wifi_cellular
+
   case appleTv1g
   case appleTv2g
   case appleTv3g_2012

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ iPad Pro 12.9-Inch (Wi-Fi Only - 2nd Gen) | ```ipad_PRO_2G_WIFI``` | ```iPad7,1`
 iPad Pro 12.9-Inch (Wi-Fi/Cell - 2nd Gen) | ```ipad_PRO_2G_WIFI_CELLULAR``` | ```iPad7,2```
 iPad Pro 10.5-Inch (Wi-Fi Only) | ```ipad_PRO_105_WIFI``` | ```iPad7,3```
 iPad Pro 10.5-Inch (Wi-Fi/Cellular) | ```ipad_PRO_105_WIFI_CELLULAR``` | ```iPad7,4```
+iPad 9.7-Inch 2018 Wifi  | ```ipad_6_WIFI``` | ```iPad7,5```
+iPad 9.7-Inch 2018 Wifi + Cellular | ```ipad_6_WIFI_CELLULAR``` | ```iPad7,6```
 
 ##### Apple TV
 Device | hardware() | hardwareString()


### PR DESCRIPTION
This PR adds the 2018 9.7-Inch iPad models to `DeviceGuru`, and bumps the pod minor version.

There isn't a ton of consistency in how iPads are named/referenced, so I'm open to feedback on whether this should be referred to as the 2018 version or the 6th generation.