### PR TITLE
On a iPhone 7 with iOS 12.1, using Xcode 10.1 Beta 3, the method hard…

### DIFF
--- a/DeviceGuru.swift
+++ b/DeviceGuru.swift
@@ -229,11 +229,11 @@ open class DeviceGuru {
   /// This method returns the hardware number not actual but logically.
   /// e.g. if the hardware string is 5,1 then hardware number would be 5.1
   ///
- public func hardwareNumber() -> Float? {
+ public func hardwareNumber() -> Double? {
     let hardware = hardwareString()
 
     let hardwareDetail = self.deviceListDict[hardware] as? [String: AnyObject]
-      if let hardwareNumber = hardwareDetail?["version"] as? Float {
+      if let hardwareNumber = hardwareDetail?["version"] as? Double {
         return hardwareNumber
       }
 


### PR DESCRIPTION
On a iPhone 7 with iOS 12.1, using Xcode 10.1 Beta 3, the method hardwareNumber returned nil instead of the phone version (9.2 in this case).
Changing the method return type from Float to Double fixed the problem.