### PR TITLE
Remove China from description for iPhone11,6

### DIFF
--- a/DeviceList.plist
+++ b/DeviceList.plist
@@ -217,7 +217,7 @@
 		<key>version</key>
 		<real>11.6</real>
 		<key>name</key>
-		<string>iPhone XS Max China</string>
+		<string>iPhone XS Max</string>
 	</dict>
 	<key>iPhone11,8</key>
 	<dict>


### PR DESCRIPTION
I have an iPhoneXS Max in the US, which was purchased directly from AT&T Wireless and it is reporting as iPhone11,6.

Various references say that 11,4 is the China variant, while a few others don't specify a difference between 11,4 and 11,6. Some do concur that 11,6 is China.

https://ipsw.me/iPhone11,4
https://ipsw.me/iPhone11,6
https://www.theiphonewiki.com/wiki/Models
https://gist.github.com/adamawolf/3048717

I haven't been able to find anything directly from Apple which identifies the variants.

Given the ambiguity of the designation at this point in time, I believe the best thing to do is remove the China designation and just mark them both as simply XS Max. If it is really desired to mark one as China, I believe the 11,4 is more likely to be the China variant.