### PR TITLE
Separate DeviceList into pod subspec

### DIFF
--- a/DeviceGuru.podspec
+++ b/DeviceGuru.podspec
@@ -7,12 +7,9 @@ Pod::Spec.new do |spec|
   spec.social_media_url    = "https://twitter.com/ikr_303"
   spec.authors = { 'Inder Kumar Rathore' => '' }
   spec.source = { :git => 'https://github.com/InderKumarRathore/DeviceGuru.git', :tag => spec.version }
-  spec.ios.deployment_target = '8.0'
   spec.requires_arc = true
   spec.swift_versions = ['3.2', '4.0', '4.2', '5.0']
-  spec.ios.deployment_target = '8.0'
-  spec.tvos.deployment_target = '9.0'
-  spec.watchos.deployment_target = '2.0'
+  spec.platforms = { :ios => "8.0", :tvos => "9.0", :watchos => "2.0" }
 
   spec.default_subspec  = "DeviceGuru"
 

--- a/DeviceGuru.podspec
+++ b/DeviceGuru.podspec
@@ -8,11 +8,21 @@ Pod::Spec.new do |spec|
   spec.authors = { 'Inder Kumar Rathore' => '' }
   spec.source = { :git => 'https://github.com/InderKumarRathore/DeviceGuru.git', :tag => spec.version }
   spec.ios.deployment_target = '8.0'
-  spec.source_files = 'Source/*.swift'
-  spec.resource_bundles = {spec.name => ['Source/DeviceList.plist']}
   spec.requires_arc = true
   spec.swift_versions = ['3.2', '4.0', '4.2', '5.0']
   spec.ios.deployment_target = '8.0'
   spec.tvos.deployment_target = '9.0'
   spec.watchos.deployment_target = '2.0'
+
+  spec.default_subspec  = "DeviceGuru"
+
+  spec.subspec "DeviceGuru" do |ss|
+    ss.dependency "DeviceGuru/Resources"
+    ss.source_files = "Source/*.swift"
+  end
+
+  spec.subspec "Resources" do |ss|
+    ss.resource_bundle = { spec.name => 'Source/DeviceList.plist' }
+  end
+
 end


### PR DESCRIPTION
This PR separates out the `DeviceList` to its independently retrievable via specificying:

`pod DeviceGuru/Resources`