### PR TITLE
Add iPhone 12 Mini, 12, 12 Pro and 12 Pro Max

### DIFF
--- a/Generator/GeneratorDeviceList.plist
+++ b/Generator/GeneratorDeviceList.plist
@@ -326,6 +326,42 @@
 		<key>enum</key>
 		<string>IPHONE_SE_2G</string>
 	</dict>
+	<key>iPhone13,1</key>
+	<dict>
+		<key>version</key>
+		<real>13.1</real>
+		<key>name</key>
+		<string>iPhone 12 mini</string>
+		<key>enum</key>
+		<string>IPHONE_12_MINI</string>
+	</dict>
+	<key>iPhone13,2</key>
+	<dict>
+		<key>version</key>
+		<real>13.2</real>
+		<key>name</key>
+		<string>iPhone 12</string>
+		<key>enum</key>
+		<string>IPHONE_12</string>
+	</dict>
+	<key>iPhone13,3</key>
+	<dict>
+		<key>version</key>
+		<real>13.3</real>
+		<key>name</key>
+		<string>iPhone 12 Pro</string>
+		<key>enum</key>
+		<string>IPHONE_12_PRO</string>
+	</dict>
+	<key>iPhone13,4</key>
+	<dict>
+		<key>version</key>
+		<real>13.4</real>
+		<key>name</key>
+		<string>iPhone 12 Pro Max</string>
+		<key>enum</key>
+		<string>IPHONE_12_PRO_MAX</string>
+	</dict>
 	<key>iPod1,1</key>
 	<dict>
 		<key>version</key>

--- a/Source/DeviceGuru+Extension.swift
+++ b/Source/DeviceGuru+Extension.swift
@@ -107,6 +107,10 @@ public extension DeviceGuru {
         if (hardware == "iPhone12,3") { return .iphone_11_pro }
         if (hardware == "iPhone12,5") { return .iphone_11_pro_max }
         if (hardware == "iPhone12,8") { return .iphone_se_2g }
+        if (hardware == "iPhone13,1") { return .iphone_12_mini }
+        if (hardware == "iPhone13,2") { return .iphone_12 }
+        if (hardware == "iPhone13,3") { return .iphone_12_pro }
+        if (hardware == "iPhone13,4") { return .iphone_12_pro_max }
         if (hardware == "iPhone2,1") { return .iphone_3gs }
         if (hardware == "iPhone3,1") { return .iphone_4 }
         if (hardware == "iPhone3,2") { return .iphone_4 }

--- a/Source/DeviceList.plist
+++ b/Source/DeviceList.plist
@@ -695,6 +695,34 @@
 		<key>version</key>
 		<real>12.800000000000001</real>
 	</dict>
+	<key>iPhone13,1</key>
+	<dict>
+		<key>name</key>
+		<string>iPhone 12 mini</string>
+		<key>version</key>
+		<real>13.1</real>
+	</dict>
+	<key>iPhone13,2</key>
+	<dict>
+		<key>name</key>
+		<string>iPhone 12</string>
+		<key>version</key>
+		<real>13.199999999999999</real>
+	</dict>
+	<key>iPhone13,3</key>
+	<dict>
+		<key>name</key>
+		<string>iPhone 12 Pro</string>
+		<key>version</key>
+		<real>13.300000000000001</real>
+	</dict>
+	<key>iPhone13,4</key>
+	<dict>
+		<key>name</key>
+		<string>iPhone 12 Pro Max</string>
+		<key>version</key>
+		<real>13.4</real>
+	</dict>
 	<key>iPhone2,1</key>
 	<dict>
 		<key>name</key>

--- a/Source/Hardware.swift
+++ b/Source/Hardware.swift
@@ -45,6 +45,10 @@ public enum Hardware {
     case iphone_11_pro
     case iphone_11_pro_max
     case iphone_se_2g
+    case iphone_12_mini
+    case iphone_12
+    case iphone_12_pro
+    case iphone_12_pro_max
 
     case ipod_touch_1g
     case ipod_touch_2g


### PR DESCRIPTION
This Pull Request adds support for the latest iPhones:

- iPhone 12 Mini
- iPhone 12
- iPhone 12 Pro
- iPhone 12 Pro Max

Versions from [www.theiphonewiki.com/wiki/Models](https://www.theiphonewiki.com/wiki/Models)