### PR TITLE
Example project

### DIFF
--- a/Example/DeviceGuruExample.xcodeproj/project.pbxproj
+++ b/Example/DeviceGuruExample.xcodeproj/project.pbxproj
@@ -1,0 +1,366 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		41495636254DFA34000A30D2 /* DeviceGuru in Frameworks */ = {isa = PBXBuildFile; productRef = 41495635254DFA34000A30D2 /* DeviceGuru */; };
+		41513A06254DD985005B6BDB /* DeviceGuruExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41513A05254DD985005B6BDB /* DeviceGuruExampleApp.swift */; };
+		41513A08254DD985005B6BDB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41513A07254DD985005B6BDB /* ContentView.swift */; };
+		41513A0A254DD985005B6BDB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 41513A09254DD985005B6BDB /* Assets.xcassets */; };
+		41513A0D254DD985005B6BDB /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 41513A0C254DD985005B6BDB /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		41513A02254DD985005B6BDB /* DeviceGuruExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DeviceGuruExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		41513A05254DD985005B6BDB /* DeviceGuruExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceGuruExampleApp.swift; sourceTree = "<group>"; };
+		41513A07254DD985005B6BDB /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		41513A09254DD985005B6BDB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		41513A0C254DD985005B6BDB /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		41513A0E254DD985005B6BDB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		415139FF254DD985005B6BDB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41495636254DFA34000A30D2 /* DeviceGuru in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		415139F9254DD985005B6BDB = {
+			isa = PBXGroup;
+			children = (
+				41513A04254DD985005B6BDB /* DeviceGuruExample */,
+				41513A03254DD985005B6BDB /* Products */,
+				41513A1C254DDF6D005B6BDB /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		41513A03254DD985005B6BDB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				41513A02254DD985005B6BDB /* DeviceGuruExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		41513A04254DD985005B6BDB /* DeviceGuruExample */ = {
+			isa = PBXGroup;
+			children = (
+				41513A05254DD985005B6BDB /* DeviceGuruExampleApp.swift */,
+				41513A07254DD985005B6BDB /* ContentView.swift */,
+				41513A09254DD985005B6BDB /* Assets.xcassets */,
+				41513A0E254DD985005B6BDB /* Info.plist */,
+				41513A0B254DD985005B6BDB /* Preview Content */,
+			);
+			path = DeviceGuruExample;
+			sourceTree = "<group>";
+		};
+		41513A0B254DD985005B6BDB /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				41513A0C254DD985005B6BDB /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		41513A1C254DDF6D005B6BDB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		41513A01254DD985005B6BDB /* DeviceGuruExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 41513A11254DD985005B6BDB /* Build configuration list for PBXNativeTarget "DeviceGuruExample" */;
+			buildPhases = (
+				415139FE254DD985005B6BDB /* Sources */,
+				415139FF254DD985005B6BDB /* Frameworks */,
+				41513A00254DD985005B6BDB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DeviceGuruExample;
+			packageProductDependencies = (
+				41495635254DFA34000A30D2 /* DeviceGuru */,
+			);
+			productName = DeviceGuruExample;
+			productReference = 41513A02254DD985005B6BDB /* DeviceGuruExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		415139FA254DD985005B6BDB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1210;
+				LastUpgradeCheck = 1210;
+				TargetAttributes = {
+					41513A01254DD985005B6BDB = {
+						CreatedOnToolsVersion = 12.1;
+					};
+				};
+			};
+			buildConfigurationList = 415139FD254DD985005B6BDB /* Build configuration list for PBXProject "DeviceGuruExample" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 415139F9254DD985005B6BDB;
+			packageReferences = (
+				41495634254DFA34000A30D2 /* XCRemoteSwiftPackageReference "DeviceGuru" */,
+			);
+			productRefGroup = 41513A03254DD985005B6BDB /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				41513A01254DD985005B6BDB /* DeviceGuruExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		41513A00254DD985005B6BDB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41513A0D254DD985005B6BDB /* Preview Assets.xcassets in Resources */,
+				41513A0A254DD985005B6BDB /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		415139FE254DD985005B6BDB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41513A08254DD985005B6BDB /* ContentView.swift in Sources */,
+				41513A06254DD985005B6BDB /* DeviceGuruExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		41513A0F254DD985005B6BDB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		41513A10254DD985005B6BDB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		41513A12254DD985005B6BDB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"DeviceGuruExample/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = DeviceGuruExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.DeviceGuru.DeviceGuruExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		41513A13254DD985005B6BDB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"DeviceGuruExample/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = DeviceGuruExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.DeviceGuru.DeviceGuruExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		415139FD254DD985005B6BDB /* Build configuration list for PBXProject "DeviceGuruExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41513A0F254DD985005B6BDB /* Debug */,
+				41513A10254DD985005B6BDB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		41513A11254DD985005B6BDB /* Build configuration list for PBXNativeTarget "DeviceGuruExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41513A12254DD985005B6BDB /* Debug */,
+				41513A13254DD985005B6BDB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		41495634254DFA34000A30D2 /* XCRemoteSwiftPackageReference "DeviceGuru" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/InderKumarRathore/DeviceGuru";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		41495635254DFA34000A30D2 /* DeviceGuru */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 41495634254DFA34000A30D2 /* XCRemoteSwiftPackageReference "DeviceGuru" */;
+			productName = DeviceGuru;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 415139FA254DD985005B6BDB /* Project object */;
+}

--- a/Example/DeviceGuruExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/DeviceGuruExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/DeviceGuruExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example/DeviceGuruExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/DeviceGuruExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/DeviceGuruExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/DeviceGuruExample/Assets.xcassets/Contents.json
+++ b/Example/DeviceGuruExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/DeviceGuruExample/ContentView.swift
+++ b/Example/DeviceGuruExample/ContentView.swift
@@ -1,0 +1,61 @@
+//
+//  ContentView.swift
+//  DeviceGuruExample
+//
+//  Created by Witek Bobrowski on 31/10/2020.
+//
+
+import SwiftUI
+import DeviceGuru
+
+struct ContentView: View {
+
+    private let guru = DeviceGuru()
+
+    private var name: Hardware { guru.hardware() }
+    private var code: String { guru.hardwareString() }
+    private var platform: Platform { guru.platform() }
+    private var description: String? { guru.hardwareDescription() }
+
+    var body: some View {
+        VStack {
+            Text(description ?? "This Device")
+                .font(.title3).padding(.bottom)
+            HStack {
+                VStack {
+                    headline("Device Name")
+                    headline("Device Code")
+                    headline("Platform")
+                }
+                VStack {
+                    value(String(describing: name))
+                    value(code)
+                    value(String(describing: platform))
+                }
+            }
+        }.padding()
+        .background(Color(white: 0.92, opacity: 1))
+        .clipShape(RoundedRectangle(cornerRadius: 25.0))
+        .padding()
+    }
+
+    private func value(_ text: String) -> some View {
+        Text(text)
+            .multilineTextAlignment(.leading)
+            .frame(minWidth: 0, idealWidth: 100, maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func headline(_ text: String) -> some View {
+        Text(text)
+            .font(.headline)
+            .multilineTextAlignment(.trailing)
+            .frame(minWidth: 0, idealWidth: 100, maxWidth: .infinity, alignment: .trailing)
+    }
+
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Example/DeviceGuruExample/DeviceGuruExampleApp.swift
+++ b/Example/DeviceGuruExample/DeviceGuruExampleApp.swift
@@ -1,0 +1,17 @@
+//
+//  DeviceGuruExampleApp.swift
+//  DeviceGuruExample
+//
+//  Created by Witek Bobrowski on 31/10/2020.
+//
+
+import SwiftUI
+
+@main
+struct DeviceGuruExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Example/DeviceGuruExample/Info.plist
+++ b/Example/DeviceGuruExample/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Example/DeviceGuruExample/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Example/DeviceGuruExample/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ let deviceCode = deviceGuru.hardwareString()
 let platform = deviceGuru.platform()
 print("\(deviceName) - \(deviceCode) - \(platform)") //Ex: iphone_7_PLUS - iPhone9,2 - iphone
 ```
-Checkout [`ExampleProject`](Example/)
+Checkout [`Example Project`](Example/)!
 
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Add to Package.swift:
 
 ```swift
-.Package(url: "https://github.com/InderKumarRathore/DeviceGuru", from: "6.0.7")
+.Package(url: "https://github.com/InderKumarRathore/DeviceGuru", branch: "master")
 ```
 
 ##### Using CocoaPods
@@ -54,8 +54,9 @@ let deviceGuru = DeviceGuru()
 let deviceName = deviceGuru.hardware()
 let deviceCode = deviceGuru.hardwareString()
 let platform = deviceGuru.platform()
-print("\(deviceName) - \(deviceCode) - \(platform.rawValue)") //Ex: iphone_7_PLUS - iPhone9,2 - iphone
+print("\(deviceName) - \(deviceCode) - \(platform)") //Ex: iphone_7_PLUS - iPhone9,2 - iphone
 ```
+Checkout [`ExampleProject`](Example/)
 
 
 ### Development


### PR DESCRIPTION
This PR adds simple Example Project for DeviceGuru! 

> WARNING! It's important to merge #81 before running the project so it can properly load needed plist file.

The App consists of a single SwiftUI view that displays information of current device. I have decided to also take advantage of the Swift Package Manager support built in Xcode to add the DeviceGuru library as the dependency.

Also, README now references Example Project right below the example usage of the library APIs.

<img width="1140" alt="Screenshot 2020-10-31 at 21 02 28" src="https://user-images.githubusercontent.com/18266391/97789126-301ee780-1bbe-11eb-9d2b-96cf54f4427b.png">

Would love to have this PR be labeled as hacktoberfest-accepted once it meets all requirements and is ready for merge.

Thanks!