### PR TITLE
Add iPad Air 4 models

### DIFF
--- a/Generator/GeneratorDeviceList.plist
+++ b/Generator/GeneratorDeviceList.plist
@@ -737,6 +737,20 @@
 		<key>enum</key>
 		<string>IPAD_AIR_3_WIFI_CELLULAR</string>
 	</dict>
+	<key>iPad13,1</key>
+	<dict>
+	    <key>name</key>
+	    <string>iPad Air 4 (Wi-Fi)</string>
+	    <key>enum</key>
+	    <string>IPAD_AIR_4_WIFI</string>
+	</dict>
+	<key>iPad13,2</key>
+	<dict>
+	    <key>name</key>
+	    <string>iPad Air 4 (Wi-Fi + Cellular)</string>
+    	<key>enum</key>
+    	<string>IPAD_AIR_4_WIFI_CELLULAR</string>
+	</dict>
 	<key>AppleTV1,1</key>
 	<dict>
 		<key>name</key>

--- a/Sources/DeviceGuru+Extension.swift
+++ b/Sources/DeviceGuru+Extension.swift
@@ -39,6 +39,8 @@ public extension DeviceGuru {
         if (hardware == "iPad11,2") { return .ipad_mini_5_wifi_cellular }
         if (hardware == "iPad11,3") { return .ipad_air_3_wifi }
         if (hardware == "iPad11,4") { return .ipad_air_3_wifi_cellular }
+        if (hardware == "iPad13,1") { return .ipad_air_4_wifi }
+        if (hardware == "iPad13,2") { return .ipad_air_4_wifi_cellular }
         if (hardware == "iPad2,1") { return .ipad_2_wifi }
         if (hardware == "iPad2,2") { return .ipad_2 }
         if (hardware == "iPad2,3") { return .ipad_2_cdma }

--- a/Sources/DeviceList.plist
+++ b/Sources/DeviceList.plist
@@ -157,6 +157,16 @@
 		<key>name</key>
 		<string>iPad Air 3 (Wi-Fi + Cellular)</string>
 	</dict>
+	<key>iPad13,1</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Air 4 (Wi-Fi)</string>
+	</dict>
+	<key>iPad13,2</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Air 4 (Wi-Fi + Cellular)</string>
+	</dict>
 	<key>iPad2,1</key>
 	<dict>
 		<key>name</key>

--- a/Sources/Hardware.swift
+++ b/Sources/Hardware.swift
@@ -115,6 +115,8 @@ public enum Hardware {
     case ipad_mini_5_wifi_cellular
     case ipad_air_3_wifi
     case ipad_air_3_wifi_cellular
+    case ipad_air_4_wifi
+    case ipad_air_4_wifi_cellular
 
     case apple_watch_38
     case apple_watch_42


### PR DESCRIPTION
See [#90](https://github.com/InderKumarRathore/DeviceGuru/issues/90)

I referred to [here](https://www.theiphonewiki.com/wiki/List_of_iPad_Airs#iPad_Air_.284th_generation.29)