### PR TITLE
Add new iPads Pro, Air, and Mini

### DIFF
--- a/Generator/GeneratorDeviceList.plist
+++ b/Generator/GeneratorDeviceList.plist
@@ -800,6 +800,90 @@
 		<key>enum</key>
 		<string>IPAD_AIR_4_WIFI_CELLULAR</string>
 	</dict>
+	<key>iPad13,4</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 11-inch (3rd generation)</string>
+		<key>enum</key>
+		<string>IPAD_PRO_11_3G_WIFI</string>
+	</dict>
+	<key>iPad13,5</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 11-inch (1TB, 3rd generation)</string>
+		<key>enum</key>
+		<string>IPAD_PRO_11_3G_1TB_WIFI</string>
+	</dict>
+	<key>iPad13,6</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 11-inch (Wi-Fi + Cellular, 3rd generation)</string>
+		<key>enum</key>
+		<string>IPAD_PRO_11_3G_WIFI_CELLULAR</string>
+	</dict>
+	<key>iPad13,7</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 11-inch (1TB, Wi-Fi + Cellular, 3rd generation)</string>
+		<key>enum</key>
+		<string>IPAD_PRO_11_3G_1TB_WIFI_CELLULAR</string>
+	</dict>
+	<key>iPad13,8</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 12.9-inch (5th generation)</string>
+		<key>enum</key>
+		<string>IPAD_PRO_5G_WIFI</string>
+	</dict>
+	<key>iPad13,9</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 12.9-inch (1TB, 5th generation)</string>
+		<key>enum</key>
+		<string>IPAD_PRO_5G_1TB_WIFI</string>
+	</dict>
+	<key>iPad13,10</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 12.9-inch (WiFi + Cellular, 5th generation)</string>
+		<key>enum</key>
+		<string>IPAD_PRO_5G_WIFI_CELLULAR</string>
+	</dict>
+	<key>iPad13,11</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 12.9-inch (1TB, WiFi + Cellular, 5th generation)</string>
+		<key>enum</key>
+		<string>IPAD_PRO_5G_1TB_WIFI_CELLULAR</string>
+	</dict>
+	<key>iPad13,16</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Air (5th generation)</string>
+		<key>enum</key>
+		<string>IPAD_AIR_5_WIFI</string>
+	</dict>
+	<key>iPad13,17</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Air (WiFi + Cellular, 5th generation)</string>
+		<key>enum</key>
+		<string>IPAD_AIR_5_WIFI_CELLULAR</string>
+	</dict>
+	<key>iPad14,1</key>
+	<dict>
+		<key>name</key>
+		<string>iPad mini (6th generation)</string>
+		<key>enum</key>
+		<string>IPAD_MINI_6_WIFI</string>
+	</dict>
+	<key>iPad14,2</key>
+	<dict>
+		<key>name</key>
+		<string>iPad mini (Wi-Fi + Cellular, 6th generation)</string>
+		<key>enum</key>
+		<string>IPAD_MINI_6_WIFI_CELLULAR</string>
+	</dict>
 	<key>AppleTV1,1</key>
 	<dict>
 		<key>name</key>

--- a/Sources/DeviceGuru+Extension.swift
+++ b/Sources/DeviceGuru+Extension.swift
@@ -43,7 +43,19 @@ public extension DeviceGuru {
         if (hardware == "iPad11,6") { return .ipad_8g_wifi }
         if (hardware == "iPad11,7") { return .ipad_8g_wifi_cellular }
         if (hardware == "iPad13,1") { return .ipad_air_4_wifi }
+        if (hardware == "iPad13,10") { return .ipad_pro_5g_wifi_cellular }
+        if (hardware == "iPad13,11") { return .ipad_pro_5g_1tb_wifi_cellular }
+        if (hardware == "iPad13,16") { return .ipad_air_5_wifi }
+        if (hardware == "iPad13,17") { return .ipad_air_5_wifi_cellular }
         if (hardware == "iPad13,2") { return .ipad_air_4_wifi_cellular }
+        if (hardware == "iPad13,4") { return .ipad_pro_11_3g_wifi }
+        if (hardware == "iPad13,5") { return .ipad_pro_11_3g_1tb_wifi }
+        if (hardware == "iPad13,6") { return .ipad_pro_11_3g_wifi_cellular }
+        if (hardware == "iPad13,7") { return .ipad_pro_11_3g_1tb_wifi_cellular }
+        if (hardware == "iPad13,8") { return .ipad_pro_5g_wifi }
+        if (hardware == "iPad13,9") { return .ipad_pro_5g_1tb_wifi }
+        if (hardware == "iPad14,1") { return .ipad_mini_6_wifi }
+        if (hardware == "iPad14,2") { return .ipad_mini_6_wifi_cellular }
         if (hardware == "iPad2,1") { return .ipad_2_wifi }
         if (hardware == "iPad2,2") { return .ipad_2 }
         if (hardware == "iPad2,3") { return .ipad_2_cdma }

--- a/Sources/DeviceList.plist
+++ b/Sources/DeviceList.plist
@@ -177,10 +177,70 @@
 		<key>name</key>
 		<string>iPad Air (4th generation)</string>
 	</dict>
+	<key>iPad13,10</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 12.9-inch (WiFi + Cellular, 5th generation)</string>
+	</dict>
+	<key>iPad13,11</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 12.9-inch (1TB, WiFi + Cellular, 5th generation)</string>
+	</dict>
+	<key>iPad13,16</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Air (5th generation)</string>
+	</dict>
+	<key>iPad13,17</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Air (WiFi + Cellular, 5th generation)</string>
+	</dict>
 	<key>iPad13,2</key>
 	<dict>
 		<key>name</key>
 		<string>iPad Air 4 (Wi-Fi + Cellular, 4th generation)</string>
+	</dict>
+	<key>iPad13,4</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 11-inch (3rd generation)</string>
+	</dict>
+	<key>iPad13,5</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 11-inch (1TB, 3rd generation)</string>
+	</dict>
+	<key>iPad13,6</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 11-inch (Wi-Fi + Cellular, 3rd generation)</string>
+	</dict>
+	<key>iPad13,7</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 11-inch (1TB, Wi-Fi + Cellular, 3rd generation)</string>
+	</dict>
+	<key>iPad13,8</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 12.9-inch (5th generation)</string>
+	</dict>
+	<key>iPad13,9</key>
+	<dict>
+		<key>name</key>
+		<string>iPad Pro 12.9-inch (1TB, 5th generation)</string>
+	</dict>
+	<key>iPad14,1</key>
+	<dict>
+		<key>name</key>
+		<string>iPad mini (6th generation)</string>
+	</dict>
+	<key>iPad14,2</key>
+	<dict>
+		<key>name</key>
+		<string>iPad mini (Wi-Fi + Cellular, 6th generation)</string>
 	</dict>
 	<key>iPad2,1</key>
 	<dict>

--- a/Sources/Hardware.swift
+++ b/Sources/Hardware.swift
@@ -124,6 +124,18 @@ public enum Hardware {
     case ipad_8g_wifi_cellular
     case ipad_air_4_wifi
     case ipad_air_4_wifi_cellular
+    case ipad_pro_11_3g_wifi
+    case ipad_pro_11_3g_1tb_wifi
+    case ipad_pro_11_3g_wifi_cellular
+    case ipad_pro_11_3g_1tb_wifi_cellular
+    case ipad_pro_5g_wifi
+    case ipad_pro_5g_1tb_wifi
+    case ipad_pro_5g_wifi_cellular
+    case ipad_pro_5g_1tb_wifi_cellular
+    case ipad_air_5_wifi
+    case ipad_air_5_wifi_cellular
+    case ipad_mini_6_wifi
+    case ipad_mini_6_wifi_cellular
 
     case apple_watch_38
     case apple_watch_42


### PR DESCRIPTION
This PR adds hardware strings for the following new iPad models:
- iPad Pro 11-inch (3rd generation) _4 models_
- iPad Pro 12.9-inch (5th generation) _4 models_
- iPad Air (5th generation) _2 models_
- iPad mini (6th generation) _2 models_

I did my best to respect the enum naming conventions from prior art, but please let me know if any should be altered.