### PR TITLE
Add Privacy Manifest

### DIFF
--- a/DeviceGuru.podspec
+++ b/DeviceGuru.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'DeviceGuru'
-  spec.version = '10.0.4'
+  spec.version = '10.0.5'
   spec.license = 'MIT'
   spec.summary = 'DeviceGuru helps identifying the exact hardware type of the device. e.g. iPhone 6 or iPhone 6s.'
   spec.homepage = 'https://github.com/InderKumarRathore/DeviceGuru'
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
 
   spec.subspec "DeviceGuru" do |ss|
     ss.dependency "DeviceGuru/Resources"
-    ss.source_files = "Sources/*.swift"
+    ss.source_files = "Sources/*.swift", "Sources/*.xcprivacy"
   end
 
   spec.subspec "Resources" do |ss|

--- a/DeviceGuru.xcodeproj/project.pbxproj
+++ b/DeviceGuru.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1DE950012838E07B0064A28D /* HardwareDetailProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareDetailProvider.swift; sourceTree = "<group>"; };
 		1DE950032838E2250064A28D /* HardwareDetailProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareDetailProviderMock.swift; sourceTree = "<group>"; };
 		1DE950052838EBAA0064A28D /* HardwareDetailProviderImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareDetailProviderImplementationTests.swift; sourceTree = "<group>"; };
+		B58874C42B43E97A00EDBEAE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		"DeviceGuru::DeviceGuru::Product" /* DeviceGuru.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DeviceGuru.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* DeviceGuruImplementation+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeviceGuruImplementation+Extension.swift"; sourceTree = "<group>"; };
 		OBJ_11 /* DeviceGuruImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceGuruImplementation.swift; sourceTree = "<group>"; };
@@ -120,6 +121,7 @@
 				OBJ_12 /* Hardware.swift */,
 				1DE950012838E07B0064A28D /* HardwareDetailProvider.swift */,
 				1DB59D39256137E10040B7FE /* Platform.swift */,
+				B58874C42B43E97A00EDBEAE /* PrivacyInfo.xcprivacy */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Issue #120 
I've read all this library code and found it uses UserDefaults for:
- Load hardware details
- Save hardware details
- Save library version

<img width="534" alt="Screenshot 2024-01-02 at 16 04 45" src="https://github.com/InderKumarRathore/DeviceGuru/assets/103159356/afcd411a-0d2b-4dea-8218-13e63e683ac6">

So, based on this I put the _CA92.1_ as an Accessed API reason in the Manifest. Need more review or discussion about this, maybe there is something which I missed. All comments are much appreciated.

