### PR TITLE
Add Swift 5 to the podspec supported versions

### DIFF
--- a/DeviceGuru.podspec
+++ b/DeviceGuru.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'DeviceGuru'
-  spec.version = '10.0.4'
+  spec.version = '10.0.5'
   spec.license = 'MIT'
   spec.summary = 'DeviceGuru helps identifying the exact hardware type of the device. e.g. iPhone 6 or iPhone 6s.'
   spec.homepage = 'https://github.com/InderKumarRathore/DeviceGuru'
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
   spec.authors = { 'Inder Kumar Rathore' => '' }
   spec.source = { :git => 'https://github.com/InderKumarRathore/DeviceGuru.git', :tag => spec.version }
   spec.requires_arc = true
-  spec.swift_versions = ['4.0']
+  spec.swift_versions = ['4.0', '5.0']
   spec.platforms = { :ios => "9.0", :tvos => "9.0", :watchos => "2.0" }
 
   spec.default_subspec  = "DeviceGuru"

--- a/DeviceGuruTests/DeviceGuruTests.swift
+++ b/DeviceGuruTests/DeviceGuruTests.swift
@@ -8,7 +8,7 @@ final class DeviceGuruTests: XCTestCase {
     private var sut: DeviceGuruImplementation!
     private var localStorageMock: LocalStorageMock!
     private var hardwareDetailProviderMock: HardwareDetailProviderMock!
-    private let currentLibraryVersion = "10.0.3"
+    private let currentLibraryVersion = "10.0.5"
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
This removes the warning from Xcode asking to convert the project to Swift 5.