### PR TITLE
Update Package.swift and pod spec file

### DIFF
--- a/DeviceGuru.podspec
+++ b/DeviceGuru.podspec
@@ -1,25 +1,24 @@
 Pod::Spec.new do |spec|
   spec.name = 'DeviceGuru'
-  spec.version = '10.0.5'
+  spec.version = '10.0.6'
   spec.license = 'MIT'
   spec.summary = 'DeviceGuru helps identifying the exact hardware type of the device. e.g. iPhone 6 or iPhone 6s.'
   spec.homepage = 'https://github.com/InderKumarRathore/DeviceGuru'
-  spec.social_media_url    = "https://twitter.com/ikr_303"
   spec.authors = { 'Inder Kumar Rathore' => '' }
   spec.source = { :git => 'https://github.com/InderKumarRathore/DeviceGuru.git', :tag => spec.version }
   spec.requires_arc = true
   spec.swift_versions = ['4.0', '5.0']
-  spec.platforms = { :ios => "9.0", :tvos => "9.0", :watchos => "2.0" }
+  spec.platforms = { :ios => "12.0", :tvos => "12.0", :watchos => "4.0" }
 
   spec.default_subspec  = "DeviceGuru"
 
   spec.subspec "DeviceGuru" do |ss|
     ss.dependency "DeviceGuru/Resources"
-    ss.source_files = "Sources/*.swift", "Sources/*.xcprivacy"
+    ss.source_files = "Sources/*.swift"
   end
 
   spec.subspec "Resources" do |ss|
-    ss.resource_bundle = { spec.name => 'Sources/DeviceList.plist' }
+    ss.resource_bundle = { spec.name => ["Sources/DeviceList.plist", "Sources/PrivacyInfo.xcprivacy"] }
   end
 
 end

--- a/DeviceGuruTests/DeviceGuruTests.swift
+++ b/DeviceGuruTests/DeviceGuruTests.swift
@@ -8,7 +8,7 @@ final class DeviceGuruTests: XCTestCase {
     private var sut: DeviceGuruImplementation!
     private var localStorageMock: LocalStorageMock!
     private var hardwareDetailProviderMock: HardwareDetailProviderMock!
-    private let currentLibraryVersion = "10.0.5"
+    private let currentLibraryVersion = "10.0.6"
 
     override func setUp() {
         super.setUp()

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,10 @@ let package = Package(
             name: "DeviceGuru", 
             dependencies: [], 
             path: "Sources",
-            resources: [.copy("DeviceList.plist")]
+            resources: [
+                .copy("DeviceList.plist"),
+                .copy("PrivacyInfo.xcprivacy")
+            ]
         )
     ]
 )

--- a/Sources/DeviceGuruImplementation+Extension.swift
+++ b/Sources/DeviceGuruImplementation+Extension.swift
@@ -2,7 +2,7 @@
 public extension DeviceGuruImplementation {
 
     /// This should be same as cocoa pod version
-    static var libraryVersion: String { "10.0.4" }
+    static var libraryVersion: String { "10.0.6" }
 
     var hardware: Hardware {
 


### PR DESCRIPTION
- Added `PrivacyInfo.xcprivacy` into the `Package.swift` and `DeviceGuru.podspec`
- Updated the deployment target for iOS, tvOS and watchOS

Followed this guide: https://apnspush.com/add-privacy-manifest-sdk